### PR TITLE
fix: filter DOLicenses from license information in file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,9 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ fn license_information_to_spdx_expressions(
 ) -> Vec<String> {
     license_information
         .into_iter()
+        .filter(|lic| !lic.starts_with("DOLicense"))
         // Remove No_license_found
         .filter(|lic| lic != "No_license_found")
         // Remove Dual-license
@@ -396,10 +397,7 @@ mod test_super {
         );
         assert_eq!(
             file_3.license_information_in_file,
-            vec![
-                "LicenseRef-GPL-2.0-or-later-WITH-Autoconf-exception-2.0".to_string(),
-                "GPL-2.0-or-later".to_string()
-            ]
+            vec!["GPL-2.0-or-later".to_string()]
         );
         assert_eq!(
             file_3.concluded_license,


### PR DESCRIPTION
DOLicenses are custom licenses created in Fossology to help convey
complex SPDX expressions that Fossology doesn't support. They're meant
to be used as conclusions, but some may end up in scanner findings as
well, which causes errors in SPDX to ORT conversion. Fix this by
filtering all DOLicenses from the scanner findings when populating SPDX
from Fossology.
