### PR TITLE
fix: don't replace + signs in licenses

### DIFF
--- a/src/doubleopen.rs
+++ b/src/doubleopen.rs
@@ -229,9 +229,7 @@ fn is_do_exception_license(license: &str) -> bool {
 
 /// Sanitize string to conform to SPDX license expression spec.
 fn sanitize_spdx_expression(lic: String) -> String {
-    let lic = lic.replace(&['(', ')', '[', ']'][..], "");
-    // TODO: No need to replace + if it's the last character.
-    lic.replace("+", "-or-later")
+    lic.replace(&['(', ')', '[', ']'][..], "")
 }
 
 /// Convert Fossology's conclusions to SPDX Expression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,9 +260,7 @@ fn license_information_to_spdx_expressions(
 
 /// Sanitize string to conform to SPDX license expression spec.
 fn sanitize_spdx_expression(lic: String) -> String {
-    let lic = lic.replace(&['(', ')', '[', ']'][..], "");
-    // TODO: No need to replace + if it's the last character.
-    lic.replace("+", "-or-later")
+    lic.replace(&['(', ')', '[', ']'][..], "")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Handle incorrect + signs in Fossology to allow using + sings in correct
SPDX expressions.
