### PR TITLE
fix: don't add duplicate LicenseRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,9 @@ fn license_information_to_spdx_expressions(
         .map(|lic| lic.replace(" ", "-"))
         // Add LicenseRefs
         .map(|lic| {
-            if license_list.includes_license(&lic.replace("+", "")) {
+            if license_list.includes_license(&lic.replace("+", ""))
+                || lic.starts_with("LicenseRef-")
+            {
                 lic
             } else {
                 format!("LicenseRef-{}", lic)


### PR DESCRIPTION
Some license findings from Fossology already include "Licenseref" in the
name of the license. Don't add LicenseRef to these.
