### PR TITLE
fix: Fix path expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.12"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
  "atty",
  "bitflags",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "doubleopen_cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ enum FossologyAction {
     /// Upload source archives to Fossology.
     Upload {
         /// Source archives to upload to Fossology. Use pattern matching to upload multiple files.
-        #[clap(short, long, parse(from_os_str), value_hint = ValueHint::FilePath)]
         source_archive_paths: Vec<PathBuf>,
 
         /// ID of the folder in Fossology to upload the source to.


### PR DESCRIPTION
Path expansion for a flag does not work for some reason. Switch to
positional argument for archives to be uploaded.